### PR TITLE
Add support for KiCAD 6.99 (VECTOR2I / wxPoint + GetOrientation().AsDegrees())

### DIFF
--- a/Snap2Grid/snap2grid.py
+++ b/Snap2Grid/snap2grid.py
@@ -12,9 +12,11 @@
 #import pcbnew;pcbnew.GetWizardsBackTrace()
 
 __version__ = '1.2.2'
-import sys, os
-import pcbnew
 import datetime
+import os
+import sys
+
+import pcbnew
 import wx
 from pcbnew import *
 
@@ -99,7 +101,9 @@ class snap_to_grid( pcbnew.ActionPlugin ):
 
     def Run(self):
         #self.pcb = GetBoard()
-        import sys,os
+        import os
+        import sys
+
         #mm_ius = 1000000.0
         #_pcbnew_frame = [x for x in wx.GetTopLevelWindows() if x.GetTitle().lower().startswith('pcbnew')][0]
         pcbnew_window = find_pcbnew_w()
@@ -154,7 +158,10 @@ def snap2grid(gridSizeMM,use_grid):
                 #print(mpxOnG,mpyOnG)
                 locked=''
                 if not module.IsLocked():
-                    module.SetPosition(wxPoint(mpxOnG,mpyOnG))
+                    if "6.99" in GetBuildVersion():
+                        module.SetPosition(VECTOR2I(mpxOnG,mpyOnG))
+                    else:
+                        module.SetPosition(wxPoint(mpxOnG,mpyOnG))
                 else:
                     locked='LOCKED'
                 X_POS=str(module.GetPosition().x) # - gridOrigin.x)
@@ -177,7 +184,10 @@ def snap2grid(gridSizeMM,use_grid):
                 #print(mpxOnG,mpyOnG)
                 locked=''
                 if not module.IsLocked():
-                    module.SetPosition(wxPoint(mpxOnG,mpyOnG))
+                    if "6.99" in GetBuildVersion():
+                        module.SetPosition(VECTOR2I(mpxOnG,mpyOnG))
+                    else:
+                        module.SetPosition(wxPoint(mpxOnG,mpyOnG))
                 else:
                     locked='LOCKED'
                 X_POS=str(module.GetPosition().x) # - gridOrigin.x)
@@ -198,7 +208,10 @@ def snap2grid(gridSizeMM,use_grid):
                 mpyOnG = int(mpy/FromMM(gridSizeMM))*FromMM(gridSizeMM) #+ auxOrigin.y
                 locked=''
                 if not module.IsLocked():
-                    module.SetPosition(wxPoint(mpxOnG,mpyOnG))
+                    if "6.99" in GetBuildVersion():
+                        module.SetPosition(VECTOR2I(mpxOnG,mpyOnG))
+                    else:
+                        module.SetPosition(wxPoint(mpxOnG,mpyOnG))
                 else:
                     locked='LOCKED'
                 X_POS=str(module.GetPosition().x) # - gridOrigin.x)
@@ -209,7 +222,10 @@ def snap2grid(gridSizeMM,use_grid):
             Value = str(module.GetValue())
             Value=(Value[:17] + '..') if len(Value) > 19 else Value
             Value="{0:<20}".format(Value)
-            Rotation='{0:.1f}'.format((module.GetOrientation()/10))
+            if "6.99" in GetBuildVersion():
+                Rotation='{0:.1f}'.format((module.GetOrientation().AsDegrees()/10))
+            else:
+                Rotation='{0:.1f}'.format((module.GetOrientation()/10))
             Rotation="{0:>6}".format(Rotation)+'  '
             if module.GetLayer() == 0:
                 Layer="  top"

--- a/Snap2Grid/snap2grid.py
+++ b/Snap2Grid/snap2grid.py
@@ -12,13 +12,22 @@
 #import pcbnew;pcbnew.GetWizardsBackTrace()
 
 __version__ = '1.2.2'
-import datetime
-import os
-import sys
-
+import sys, os
 import pcbnew
+import datetime
 import wx
 from pcbnew import *
+
+# Make snap2grid compatible with KiCAD 6.99
+if "6.99" in GetBuildVersion():
+    wxPoint = VECTOR2I
+
+def getOrientation(fp):
+    o = fp.GetOrientation()
+    if "6.99" in GetBuildVersion():
+        return o.AsDegrees()
+    return o / 10
+
 
 use_grid_origin = True
 
@@ -101,9 +110,7 @@ class snap_to_grid( pcbnew.ActionPlugin ):
 
     def Run(self):
         #self.pcb = GetBoard()
-        import os
-        import sys
-
+        import sys,os
         #mm_ius = 1000000.0
         #_pcbnew_frame = [x for x in wx.GetTopLevelWindows() if x.GetTitle().lower().startswith('pcbnew')][0]
         pcbnew_window = find_pcbnew_w()
@@ -158,10 +165,7 @@ def snap2grid(gridSizeMM,use_grid):
                 #print(mpxOnG,mpyOnG)
                 locked=''
                 if not module.IsLocked():
-                    if "6.99" in GetBuildVersion():
-                        module.SetPosition(VECTOR2I(mpxOnG,mpyOnG))
-                    else:
-                        module.SetPosition(wxPoint(mpxOnG,mpyOnG))
+                    module.SetPosition(wxPoint(mpxOnG,mpyOnG))
                 else:
                     locked='LOCKED'
                 X_POS=str(module.GetPosition().x) # - gridOrigin.x)
@@ -184,10 +188,7 @@ def snap2grid(gridSizeMM,use_grid):
                 #print(mpxOnG,mpyOnG)
                 locked=''
                 if not module.IsLocked():
-                    if "6.99" in GetBuildVersion():
-                        module.SetPosition(VECTOR2I(mpxOnG,mpyOnG))
-                    else:
-                        module.SetPosition(wxPoint(mpxOnG,mpyOnG))
+                    module.SetPosition(wxPoint(mpxOnG,mpyOnG))
                 else:
                     locked='LOCKED'
                 X_POS=str(module.GetPosition().x) # - gridOrigin.x)
@@ -208,10 +209,7 @@ def snap2grid(gridSizeMM,use_grid):
                 mpyOnG = int(mpy/FromMM(gridSizeMM))*FromMM(gridSizeMM) #+ auxOrigin.y
                 locked=''
                 if not module.IsLocked():
-                    if "6.99" in GetBuildVersion():
-                        module.SetPosition(VECTOR2I(mpxOnG,mpyOnG))
-                    else:
-                        module.SetPosition(wxPoint(mpxOnG,mpyOnG))
+                    module.SetPosition(wxPoint(mpxOnG,mpyOnG))
                 else:
                     locked='LOCKED'
                 X_POS=str(module.GetPosition().x) # - gridOrigin.x)
@@ -222,10 +220,7 @@ def snap2grid(gridSizeMM,use_grid):
             Value = str(module.GetValue())
             Value=(Value[:17] + '..') if len(Value) > 19 else Value
             Value="{0:<20}".format(Value)
-            if "6.99" in GetBuildVersion():
-                Rotation='{0:.1f}'.format((module.GetOrientation().AsDegrees()/10))
-            else:
-                Rotation='{0:.1f}'.format((module.GetOrientation()/10))
+            Rotation='{0:.1f}'.format(getOrientation(module))
             Rotation="{0:>6}".format(Rotation)+'  '
             if module.GetLayer() == 0:
                 Layer="  top"

--- a/Snap2Grid/snaptogrid_script.py
+++ b/Snap2Grid/snaptogrid_script.py
@@ -6,14 +6,24 @@
 # 
 #
 
-import datetime
-import os
 #import snaptogrid; import importlib; importlib.reload(snaptogrid)
-import sys
-
+import sys, os
 import pcbnew
+import datetime
 import wx
 from pcbnew import *
+
+
+# Make snap2grid compatible with KiCAD 6.99
+if "6.99" in GetBuildVersion():
+    wxPoint = VECTOR2I
+
+def getOrientation(fp):
+    o = fp.GetOrientation()
+    if "6.99" in GetBuildVersion():
+        return o.AsDegrees()
+    return o / 10
+
 
 use_grid_origin = True
 gridReference = 0.127 #1.27 #mm pcbnew.FromMM(1.0) #0.1mm
@@ -32,9 +42,7 @@ gridReference = 0.127 #1.27 #mm pcbnew.FromMM(1.0) #0.1mm
 
 
 def Snap2Grid(gridSizeMM,use_grid_origin):
-    import os
-    import sys
-
+    import sys,os
     #mm_ius = 1000000.0
     
     pcb = pcbnew.GetBoard()
@@ -51,10 +59,7 @@ def Snap2Grid(gridSizeMM,use_grid_origin):
                 mpxOnG = int(mpx/FromMM(gridSizeMM))*FromMM(gridSizeMM)+ gridOrigin.x
                 mpyOnG = int(mpy/FromMM(gridSizeMM))*FromMM(gridSizeMM)+ gridOrigin.y
                 print(mpxOnG,mpyOnG)
-                if "6.99" in GetBuildVersion():
-                    module.SetPosition(VECTOR2I(mpxOnG,mpyOnG))
-                else:
-                    module.SetPosition(wxPoint(mpxOnG,mpyOnG))
+                module.SetPosition(wxPoint(mpxOnG,mpyOnG))
                 X_POS=str(module.GetPosition().x) # - gridOrigin.x)
                 #X_POS='{0:.4f}'.format(pcbnew.ToMM(module.GetPosition().x - gridOrigin.x ))
                 X_POS="{0:<11}".format(X_POS)
@@ -77,7 +82,7 @@ def Snap2Grid(gridSizeMM,use_grid_origin):
             Value = str(module.GetValue())
             Value=(Value[:17] + '..') if len(Value) > 19 else Value
             Value="{0:<20}".format(Value)
-            Rotation='{0:.1f}'.format((module.GetOrientation()/10))
+            Rotation='{0:.1f}'.format(getOrientation(module))
             Rotation="{0:>6}".format(Rotation)+'  '
             if module.GetLayer() == 0:
                 Layer="  top"

--- a/Snap2Grid/snaptogrid_script.py
+++ b/Snap2Grid/snaptogrid_script.py
@@ -6,10 +6,12 @@
 # 
 #
 
-#import snaptogrid; import importlib; importlib.reload(snaptogrid)
-import sys, os
-import pcbnew
 import datetime
+import os
+#import snaptogrid; import importlib; importlib.reload(snaptogrid)
+import sys
+
+import pcbnew
 import wx
 from pcbnew import *
 
@@ -30,7 +32,9 @@ gridReference = 0.127 #1.27 #mm pcbnew.FromMM(1.0) #0.1mm
 
 
 def Snap2Grid(gridSizeMM,use_grid_origin):
-    import sys,os
+    import os
+    import sys
+
     #mm_ius = 1000000.0
     
     pcb = pcbnew.GetBoard()
@@ -47,7 +51,10 @@ def Snap2Grid(gridSizeMM,use_grid_origin):
                 mpxOnG = int(mpx/FromMM(gridSizeMM))*FromMM(gridSizeMM)+ gridOrigin.x
                 mpyOnG = int(mpy/FromMM(gridSizeMM))*FromMM(gridSizeMM)+ gridOrigin.y
                 print(mpxOnG,mpyOnG)
-                module.SetPosition(wxPoint(mpxOnG,mpyOnG))
+                if "6.99" in GetBuildVersion():
+                    module.SetPosition(VECTOR2I(mpxOnG,mpyOnG))
+                else:
+                    module.SetPosition(wxPoint(mpxOnG,mpyOnG))
                 X_POS=str(module.GetPosition().x) # - gridOrigin.x)
                 #X_POS='{0:.4f}'.format(pcbnew.ToMM(module.GetPosition().x - gridOrigin.x ))
                 X_POS="{0:<11}".format(X_POS)


### PR DESCRIPTION
This fixes #15 so the plugin works for 6.0 as well as for 6.99