### PR TITLE
Fix #22:

### DIFF
--- a/MoveToLayer/move_to_layer.py
+++ b/MoveToLayer/move_to_layer.py
@@ -154,8 +154,7 @@ class move_to_draw_layer( pcbnew.ActionPlugin ):
             if modal_result == wx.ID_OK:
                 LayerName = aParameters.m_comboBoxLayer.GetStringSelection()
                 LayerIndex = aParameters.m_comboBoxLayer.FindString(LayerName)
-                LayerStdName = pcbnew.BOARD_GetStandardLayerName(LayerIndex)
-                #wx.LogMessage(LayerName+';'+str(LayerIndex)+';'+LayerStdName)
+                # wx.LogMessage(LayerName+';'+str(LayerIndex))
                 MoveToLayer(board, LayerIndex)
             else:
                 None  # Cancel


### PR DESCRIPTION
Simply removing the line does it as `LayerStdName` is not being used anywhere apart from a commented out logging statement. I'm not entirely sure how this broke, as the binding is still exposed in https:// docs.kicad.org/doxygen-python-nightly/namespacepcbnew.html.